### PR TITLE
Supports UTF-8 value

### DIFF
--- a/django_simple_aes_field/fields.py
+++ b/django_simple_aes_field/fields.py
@@ -16,11 +16,11 @@ class AESField(models.CharField):
         return super(AESField, self).__init__(*args, **kwargs)
 
     def get_prep_value(self, value):
-        return aes.base64_encrypt(str(value))
+        return aes.base64_encrypt(value.encode("utf-8"))
 
     def to_python(self, value):
         try:
-            return aes.base64_decrypt(value)
+            return aes.base64_decrypt(value).decode("utf-8")
         except:
             return value
 


### PR DESCRIPTION
Using `str(value)` breaks if the value is not ascii-encodable. This patch use `value.encode` instead to allow UTF-8 value to be encoded.
