### PR TITLE
Add SubfieldBase to call to_python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+ - Add `metaclass` for `SubfieldBase` to call `to_python` when getting value
+ back from the database.
+
+
 ## v1.0.0
 
  - Add tests

--- a/django_field_cryptography/fields.py
+++ b/django_field_cryptography/fields.py
@@ -23,13 +23,15 @@ class EncryptedTextField(with_metaclass(models.SubfieldBase, models.TextField)):
         return fernet.encrypt(force_bytes(value))
 
     def to_python(self, value):
-        """Returns unencrypted or decrypted value."""
+        """
+        Returns unencrypted or decrypted value.
 
-        # `to_python` is called either when assigning a value to the model or
-        # when retrieving a value from it. It should be either be able to return
-        # the string assigned or to decrypt it. This behavior (from django) is
-        # not ideal but will change in the future see
-        # https://docs.djangoproject.com/en/dev/howto/custom-model-fields/#converting-values-to-python-objects
+        `to_python` is called either when assigning a value to the model or
+        when retrieving a value from it. It should be either be able to return
+        the string assigned or to decrypt it. This behavior (from django) is
+        not ideal but will change in the future see
+        https://docs.djangoproject.com/en/dev/howto/custom-model-fields/#converting-values-to-python-objects
+        """
         try:
             value = fernet.decrypt(force_bytes(value))
         except InvalidToken:

--- a/django_field_cryptography/fields.py
+++ b/django_field_cryptography/fields.py
@@ -1,25 +1,33 @@
 from django.conf import settings
 from django.db import models
 from django.utils.encoding import force_bytes, force_str
+from django.utils.six import with_metaclass
 
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
 
 
 fernet = Fernet(settings.FERNET_KEY)
 
 
-class EncryptedTextField(models.TextField):
+class EncryptedTextField(with_metaclass(models.SubfieldBase, models.TextField)):
     """A TextField encrypted with Fernet (AES).
 
     EncryptedTextField rely on `Fernet` from `cryptography` to ensure symetric
     encryption. This field is compatible with South migrations.
     """
+    def db_type(self, connection):
+        return 'bytea'
+
     def get_prep_value(self, value):
         return fernet.encrypt(force_bytes(value))
 
     def to_python(self, value):
-        decrypted = fernet.decrypt(value)
-        return force_str(decrypted)
+        try:
+            value = fernet.decrypt(force_bytes(value))
+        except InvalidToken:
+            return value
+        else:
+            return force_str(value)
 
     def south_field_triple(self):
         """Returns a suitable description of this field for South."""

--- a/django_field_cryptography/fields.py
+++ b/django_field_cryptography/fields.py
@@ -22,6 +22,8 @@ class EncryptedTextField(with_metaclass(models.SubfieldBase, models.TextField)):
         return fernet.encrypt(force_bytes(value))
 
     def to_python(self, value):
+        """to_python is called every time an instance of the field is
+        assigned a value and when retrieving the value from the database."""
         try:
             value = fernet.decrypt(force_bytes(value))
         except InvalidToken:

--- a/django_field_cryptography/fields.py
+++ b/django_field_cryptography/fields.py
@@ -16,14 +16,20 @@ class EncryptedTextField(with_metaclass(models.SubfieldBase, models.TextField)):
     encryption. This field is compatible with South migrations.
     """
     def db_type(self, connection):
+        """Value stored in the database is hexadecimal."""
         return 'bytea'
 
     def get_prep_value(self, value):
         return fernet.encrypt(force_bytes(value))
 
     def to_python(self, value):
-        """to_python is called every time an instance of the field is
-        assigned a value and when retrieving the value from the database."""
+        """Returns unencrypted or decrypted value."""
+
+        # `to_python` is called either when assigning a value to the model or
+        # when retrieving a value from it. It should be either be able to return
+        # the string assigned or to decrypt it. This behavior (from django) is
+        # not ideal but will change in the future see
+        # https://docs.djangoproject.com/en/dev/howto/custom-model-fields/#converting-values-to-python-objects
         try:
             value = fernet.decrypt(force_bytes(value))
         except InvalidToken:

--- a/django_field_cryptography/tests/test_fields.py
+++ b/django_field_cryptography/tests/test_fields.py
@@ -3,7 +3,7 @@
 from django.test import TestCase
 
 from .. import fields
-from . import factories
+from . import factories, models
 
 
 class TestField(TestCase):
@@ -31,5 +31,6 @@ class TestField(TestCase):
 class TestModel(TestCase):
     def test_value(self):
         value = 'Encrypt me'
-        dummy_model = factories.DummyModelFactory.create(aes_field=value)
+        factories.DummyModelFactory.create(aes_field=value)
+        dummy_model = models.DummyModel.objects.get()
         self.assertEqual(dummy_model.aes_field, value)

--- a/django_field_cryptography/tests/test_fields.py
+++ b/django_field_cryptography/tests/test_fields.py
@@ -32,5 +32,8 @@ class TestModel(TestCase):
     def test_value(self):
         value = 'Encrypt me'
         factories.DummyModelFactory.create(aes_field=value)
+
+        # requerying the model allow us to call `to_python` to test if the
+        # decryption is handled properly.
         dummy_model = models.DummyModel.objects.get()
         self.assertEqual(dummy_model.aes_field, value)


### PR DESCRIPTION
Currently `to_python` is not called when getting the value from the database
