### PR TITLE
Update namespace used in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ FERNET_KEY = b'your_key...'
 ## Usage
 
 ```python
-    from django_cryptography.fields import EncryptedTextField
+    from django_field_cryptography.fields import EncryptedTextField
 
     class MyModel(models.Model):
         my_secret_field = EncryptedTextField()


### PR DESCRIPTION
The referenced namespace does not exist, it seems that this should be changed to `django_field_cryptography`.
